### PR TITLE
plasma.emit callback called after all async listeners handler functions calls back (call done/next). otherwise hang!

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 var plasmaWithFeedbackVersion = require('./package.json').version
+var deepEqual = require('organic-plasma/lib/utils').deepEqual
+
 module.exports = function (originalPlasma) {
   if (originalPlasma.$plasmaWithFeedbackVersion) {
     if (originalPlasma.$plasmaWithFeedbackVersion !== plasmaWithFeedbackVersion) {
@@ -52,22 +54,34 @@ module.exports = function (originalPlasma) {
     }
 
     if (callback) {
+      var waitForListenersCount = 0
+      for (var i = 0, len = this.listeners.length; i < len; i++) {
+        var listener = this.listeners[i]
+        if (listener.handler && listener.handler.length > 0) {
+          if (deepEqual(listener.pattern, chemical)) {
+            waitForListenersCount++
+          }
+        }
+      }
+
       if (!chemical.$feedback_timestamp) {
         chemical.$feedback_timestamp = (new Date()).getTime() + Math.random()
-        originalPlasma.once({
-          type: chemical.type + '-result',
-          $feedback_timestamp: chemical.$feedback_timestamp
-        }, function (c) {
-          callback(c.err, c.result)
-        })
-      } else {
-        originalPlasma.on({
-          type: chemical.type + '-result',
-          $feedback_timestamp: chemical.$feedback_timestamp
-        }, function (c) {
-          callback(c.err, c.result)
-        })
       }
+
+      var resultChemical = {
+        type: chemical.type + '-result',
+        $feedback_timestamp: chemical.$feedback_timestamp
+      }
+
+      var waitForListenersHandler = function (c) {
+        waitForListenersCount--
+        if (waitForListenersCount <= 0) {
+          originalPlasma.off(resultChemical, waitForListenersHandler)
+          callback(c.err, c.result)
+        }
+      }
+
+      originalPlasma.on(resultChemical, waitForListenersHandler)
       originalPlasma.emit(chemical)
     } else {
       originalPlasma.emit(chemical)

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function (originalPlasma) {
 
     var reactionFn = handler
     if (handler.length === 2) { // has callback
-      reactionFn = function (c) {
+      reactionFn = function (c, next) {
         var chemicalType = c.type
         return handler.call(context, c, function (err, result) {
           originalPlasma.emit({
@@ -34,7 +34,7 @@ module.exports = function (originalPlasma) {
             $feedback_timestamp: c.$feedback_timestamp,
             err: err,
             result: result
-          })
+          }, next)
         })
       }
     }
@@ -57,7 +57,7 @@ module.exports = function (originalPlasma) {
       var waitForListenersCount = 0
       for (var i = 0, len = this.listeners.length; i < len; i++) {
         var listener = this.listeners[i]
-        if (listener.handler && listener.handler.length > 0) {
+        if (listener.handler && listener.handler.length === 2) {
           if (deepEqual(listener.pattern, chemical)) {
             waitForListenersCount++
           }

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function (originalPlasma) {
             $feedback_timestamp: c.$feedback_timestamp,
             err: err,
             result: result
-          }, next)
+          })
         })
       }
     }

--- a/tests/emit-and-wait-for.spec.js
+++ b/tests/emit-and-wait-for.spec.js
@@ -18,9 +18,9 @@ describe('emit and wait for async listeners (handler.length > 0) to call back', 
   })
 
   it('emit', function (done) {
-    instance.emit('kill', function (err, result) {
+    instance.emitAndWaitAll('kill', function (err, result) {
       if (err) return done(err)
-      expect(result).toBe(2)
+      expect(result).toEqual([1, 2])
       expect(handled).toBe(2)
       done()
     })
@@ -39,10 +39,10 @@ describe('emit and wait for async listeners (handler.length > 0) to call back', 
     done()
   })
 
-  it('emit', function (done) {
-    instance.emit('another', function (err, result) {
+  it('emit again', function (done) {
+    instance.emitAndWaitAll('another', function (err, result) {
       if (err) return done(err)
-      expect(result).toBe(2)
+      expect(result).toEqual([2])
       expect(handled).toBe(2)
       done()
     })
@@ -61,8 +61,8 @@ describe('emit and wait for async listeners (handler.length > 0) to call back', 
     done()
   })
 
-  it('emit', function (done) {
-    instance.emit('again', function (err, result) {
+  it('and emit again', function (done) {
+    instance.emitAndWaitAll('again', function (err, result) {
       if (err) return done(err)
       emitCallbackCalled = true
     })

--- a/tests/emit-and-wait-for.spec.js
+++ b/tests/emit-and-wait-for.spec.js
@@ -1,0 +1,79 @@
+var Plasma = require('organic-plasma')
+
+describe('emit and wait for async listeners (handler.length > 0) to call back', function () {
+  var instance = require('../index')(new Plasma())
+  var handled = 0
+  var emitCallbackCalled = false
+
+  it('define two listeners', function (done) {
+    instance.on('kill', function (c, next) {
+      handled += 1
+      next(null, 1)
+    })
+    instance.on('kill', function (c, next) {
+      handled += 1
+      next(null, 2)
+    })
+    done()
+  })
+
+  it('emit', function (done) {
+    instance.emit('kill', function (err, result) {
+      if (err) return done(err)
+      expect(result).toBe(2)
+      expect(handled).toBe(2)
+      done()
+    })
+  })
+
+  it('define two more listeners, first without callback', function (done) {
+    handled = 0
+
+    instance.on('another', function () {
+      handled += 1
+    })
+    instance.on('another', function (c, next) {
+      handled += 1
+      next(null, 2)
+    })
+    done()
+  })
+
+  it('emit', function (done) {
+    instance.emit('another', function (err, result) {
+      if (err) return done(err)
+      expect(result).toBe(2)
+      expect(handled).toBe(2)
+      done()
+    })
+  })
+
+  it('define two more listeners, first with callback, but doesnt call next!', function (done) {
+    handled = 0
+
+    instance.on('again', function (c, next) {
+      handled += 1
+    })
+    instance.on('again', function (c, next) {
+      handled += 1
+      next(null, 2)
+    })
+    done()
+  })
+
+  it('emit', function (done) {
+    instance.emit('again', function (err, result) {
+      if (err) return done(err)
+      emitCallbackCalled = true
+    })
+    done()
+  })
+
+  it('emit callback should not be called', function (done) {
+    setTimeout(function () {
+      expect(emitCallbackCalled).toBe(false)
+      expect(handled).toBe(2)
+      done()
+    }, 100)
+  })
+})

--- a/tests/emit-and-wait-for.spec.js
+++ b/tests/emit-and-wait-for.spec.js
@@ -29,7 +29,7 @@ describe('emit and wait for async listeners (handler.length > 0) to call back', 
   it('define two more listeners, first without callback', function (done) {
     handled = 0
 
-    instance.on('another', function () {
+    instance.on('another', function (c) {
       handled += 1
     })
     instance.on('another', function (c, next) {

--- a/tests/feedback-aggregation.spec.js
+++ b/tests/feedback-aggregation.spec.js
@@ -2,10 +2,10 @@ var Plasma = require('organic-plasma')
 
 describe('feedback aggregation', function () {
   var instance = require('../index')(new Plasma())
-  var handled = 0
-  var emitCallbackCalled = false
 
   it('multiple listeners returning true are not hit simultaniously', function (done) {
+    var handled = 0
+
     instance.on('simultanious', function (c, next) {
       handled += 1
       next(null, 1)
@@ -19,17 +19,11 @@ describe('feedback aggregation', function () {
 
     instance.emit('simultanious', function (err, result) {
       if (err) return done(err)
-      emitCallbackCalled = true
+      expect(result).toBe(1)
+      setTimeout(function () {
+        expect(handled).toBe(1)
+        return done()
+      }, 100)
     })
-
-    done()
-  })
-
-  it('emit callback should not be called', function (done) {
-    setTimeout(function () {
-      expect(emitCallbackCalled).toBe(false)
-      expect(handled).toBe(1)
-      done()
-    }, 100)
   })
 })

--- a/tests/feedback-aggregation.spec.js
+++ b/tests/feedback-aggregation.spec.js
@@ -2,10 +2,10 @@ var Plasma = require('organic-plasma')
 
 describe('feedback aggregation', function () {
   var instance = require('../index')(new Plasma())
+  var handled = 0
+  var emitCallbackCalled = false
 
   it('multiple listeners returning true are not hit simultaniously', function (done) {
-    var handled = 0
-
     instance.on('simultanious', function (c, next) {
       handled += 1
       next(null, 1)
@@ -19,11 +19,17 @@ describe('feedback aggregation', function () {
 
     instance.emit('simultanious', function (err, result) {
       if (err) return done(err)
-      expect(result).toBe(1)
-      setTimeout(function () {
-        expect(handled).toBe(1)
-        return done()
-      }, 100)
+      emitCallbackCalled = true
     })
+
+    done()
+  })
+
+  it('emit callback should not be called', function (done) {
+    setTimeout(function () {
+      expect(emitCallbackCalled).toBe(false)
+      expect(handled).toBe(1)
+      done()
+    }, 100)
   })
 })


### PR DESCRIPTION
# The problem

plasma.emit callback was called on first chemical reaction

# Expected behavior

plasma.emit to wait for all listeners handler async functions to
complete then to callback our handler

# the solution

count all listener handler functions with async signature, matching the
chemical. then count back every result chemical emitted and decrement
the counter, if `counter <= 0` call the final emit callback

# misc

if one use async handler like so: `plasma.on(chemical, (c, next) =>
{})` and doesn't call next(), the final callback will hang!

handlers with signature like `plasma.on(chemical, () => {})` are
treated as sync